### PR TITLE
Update loot conditions

### DIFF
--- a/mappings/net/minecraft/loot/condition/LootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/LootCondition.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_5341 net/minecraft/loot/condition/LootCondition
 	FIELD field_51808 BASE_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_51809 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_51810 ENTRY_CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_1_745 getCodec ()Lcom/mojang/serialization/MapCodec;
 	CLASS class_210 Builder
 		METHOD method_1_327 (Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_8548$class_8549;
 			ARG 1 condition

--- a/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
+++ b/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_217 net/minecraft/loot/condition/LootConditionTypes

--- a/mappings/net/minecraft/loot/condition/LootConditions.mapping
+++ b/mappings/net/minecraft/loot/condition/LootConditions.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_217 net/minecraft/loot/condition/LootConditions
+	METHOD method_1_747 registerAndGetDefault (Lnet/minecraft/class_2378;)Lcom/mojang/serialization/MapCodec;


### PR DESCRIPTION
Loot condition type no longer exists
The registry now simply contains codecs