### PR TITLE
Begin mapping 26.1-snapshot-6

### DIFF
--- a/mappings/net/minecraft/BatchMoveFileFixer.mapping
+++ b/mappings/net/minecraft/BatchMoveFileFixer.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_1_214 net/minecraft/BatchMoveFileFixer

--- a/mappings/net/minecraft/BatchMoveFileFixer.mapping
+++ b/mappings/net/minecraft/BatchMoveFileFixer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_214 net/minecraft/BatchMoveFileFixer

--- a/mappings/net/minecraft/class_1_193.mapping
+++ b/mappings/net/minecraft/class_1_193.mapping
@@ -1,0 +1,35 @@
+CLASS net/minecraft/class_1_193
+	FIELD field_1_1427 LOGGER Lorg/slf4j/Logger;
+	FIELD field_1_1428 dataFixers Lcom/mojang/datafixers/DataFixerBuilder$Result;
+	FIELD field_1_1429 fixers Ljava/util/List;
+	FIELD field_1_1430 maxVersion I
+	METHOD <init> (Lcom/mojang/datafixers/DataFixerBuilder$Result;Ljava/util/List;I)V
+		ARG 1 dataFixers
+		ARG 2 fixers
+		ARG 3 maxVersion
+	METHOD method_1_1696 (Lnet/minecraft/class_1_27;IILjava/nio/file/Path;)Lcom/mojang/serialization/Dynamic;
+		ARG 1 progress
+	METHOD method_1_1697 count (Ljava/util/List;Lnet/minecraft/class_1_27;)V
+		ARG 2 progress
+	METHOD method_1_1699 (Lnet/minecraft/class_32$class_5143;Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_1_27;)Lcom/mojang/serialization/Dynamic;
+		ARG 1 storageSession
+		ARG 3 progress
+	METHOD method_1_1700 (Lnet/minecraft/class_32$class_5143;Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_1_27;I)Lcom/mojang/serialization/Dynamic;
+		ARG 1 storageSession
+		ARG 3 progress
+	CLASS class_1_194 Builder
+		FIELD field_1_1431 dataVersion I
+		FIELD field_1_1432 fixers Ljava/util/List;
+		FIELD field_1_1433 schemas Ljava/util/List;
+		FIELD field_1_1434 maxVersion I
+		METHOD <init> (I)V
+			ARG 1 dataVersion
+		METHOD method_1_1710 addFixer (Lnet/minecraft/class_1_187;)V
+			ARG 1 fix
+		METHOD method_1_1711 addSchema (Lcom/mojang/datafixers/DataFixerBuilder;ILjava/util/function/BiFunction;)Lcom/mojang/datafixers/schemas/Schema;
+			ARG 1 dataFixerBuilder
+			ARG 2 version
+			ARG 3 factory
+		METHOD method_1_1712 build (Lcom/mojang/datafixers/DataFixerBuilder$Result;)Lnet/minecraft/class_1_193;
+			ARG 1 dataFixers
+	CLASS class_1_195 FileSystemCapabilities

--- a/mappings/net/minecraft/class_1_196.mapping
+++ b/mappings/net/minecraft/class_1_196.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_1_196
+	FIELD field_1_1437 chunkStorage Lnet/minecraft/class_3977;
+	METHOD <init> (Lnet/minecraft/class_9240;Ljava/nio/file/Path;Lnet/minecraft/class_4284;I)V
+		ARG 1 storageKey
+		ARG 2 directory
+		ARG 3 datafixType
+	METHOD method_1_1715 (Lnet/minecraft/class_2487;Ljava/util/function/UnaryOperator;Ljava/util/Optional;)Ljava/util/Optional;
+		ARG 3 chunkNbt
+	METHOD method_1_1719 (Lnet/minecraft/class_1923;Lnet/minecraft/class_2487;Ljava/util/function/UnaryOperator;)V
+		ARG 1 chunkPos
+		ARG 3 f

--- a/mappings/net/minecraft/class_1_203.mapping
+++ b/mappings/net/minecraft/class_1_203.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1_203
+	FIELD field_1_1466 LOGGER Lorg/slf4j/Logger;
+	METHOD method_1_1745 get ()Ljava/util/List;
+	METHOD method_1_1746 getOne ()Ljava/lang/AutoCloseable;

--- a/mappings/net/minecraft/class_1_228.mapping
+++ b/mappings/net/minecraft/class_1_228.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1_228
+	CLASS class_1_230
+		METHOD method_1_1864 (Lnet/minecraft/class_1_27;)V
+			ARG 1 progress

--- a/mappings/net/minecraft/class_1_233.mapping
+++ b/mappings/net/minecraft/class_1_233.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_1_233
+	FIELD field_1_1580 path Ljava/lang/ScopedValue;
+	FIELD field_1_1581 version I
+	FIELD field_1_1582 initialized Z
+	METHOD <init> (I)V
+		ARG 1 version
+	METHOD method_1_1879 getPath ()Ljava/lang/ScopedValue;
+	METHOD method_1_1880 getVersion ()I
+	METHOD method_1_1881 setInitialized ()V

--- a/mappings/net/minecraft/client/gui/screen/world/UpgradeWorldScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/UpgradeWorldScreen.mapping
@@ -1,0 +1,43 @@
+CLASS net/minecraft/class_1_273 net/minecraft/client/gui/screen/world/UpgradeWorldScreen
+	FIELD field_1_1672 SCANNING_TEXT Lnet/minecraft/class_2561;
+	FIELD field_1_1674 progress Lnet/minecraft/class_1_27;
+	METHOD <init> (Lnet/minecraft/class_1_27;)V
+		ARG 1 progress
+	METHOD method_1_2063 drawFileFixProgress (Lnet/minecraft/class_332;IIII)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+		ARG 4 current
+		ARG 5 total
+	METHOD method_1_2064 drawConversionProgress (Lnet/minecraft/class_332;IIII)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+		ARG 4 converted
+		ARG 5 total
+	METHOD method_1_2065 renderProgress (Lnet/minecraft/class_332;II)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+	METHOD method_1_2066 drawProgressBar (Lnet/minecraft/class_332;IIF)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+		ARG 4 progress
+	METHOD method_1_2067 drawScanningText (Lnet/minecraft/class_332;II)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+	METHOD method_1_2068 drawTitle (Lnet/minecraft/class_332;II)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+	METHOD method_1_2069 drawPercentage (Lnet/minecraft/class_332;IIF)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y
+		ARG 4 percentage
+	METHOD method_1_2070 drawStageTitle (Lnet/minecraft/class_332;II)V
+		ARG 1 context
+		ARG 2 centerX
+		ARG 3 y

--- a/mappings/net/minecraft/datafixer/Schemas.mapping
+++ b/mappings/net/minecraft/datafixer/Schemas.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_3551 net/minecraft/datafixer/Schemas
 	METHOD method_15450 getFixer ()Lcom/mojang/datafixers/DataFixer;
 	METHOD method_15451 build (Lcom/mojang/datafixers/DataFixerBuilder;Lnet/minecraft/class_1_193$class_1_194;)V
 		ARG 0 builder
+		ARG 1 fileFixBuilder
 	METHOD method_15455 (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 id
 	METHOD method_15459 (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixer/file/BatchMoveFileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/BatchMoveFileFixer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_214 net/minecraft/datafixer/file/BatchMoveFileFixer

--- a/mappings/net/minecraft/datafixer/file/DeleteFileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/DeleteFileFixer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_263 net/minecraft/datafixer/file/DeleteFileFixer

--- a/mappings/net/minecraft/datafixer/file/DirectoryFileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/DirectoryFileFixer.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_1_234 net/minecraft/datafixer/file/DirectoryFileFixer
+	FIELD comp_1_170 fileFixers Ljava/util/List;
+	FIELD comp_1_171 directories Lnet/minecraft/class_1_206;
+	METHOD comp_1_170 fileFixers ()Ljava/util/List;
+	METHOD comp_1_171 directories ()Lnet/minecraft/class_1_206;

--- a/mappings/net/minecraft/datafixer/file/DirectoryPaths.mapping
+++ b/mappings/net/minecraft/datafixer/file/DirectoryPaths.mapping
@@ -1,0 +1,56 @@
+CLASS net/minecraft/class_1_206 net/minecraft/datafixer/file/DirectoryPaths
+	FIELD field_1_1480 DATA Lnet/minecraft/class_1_206;
+	FIELD field_1_1481 DIMENSIONS Lnet/minecraft/class_1_206;
+	FIELD field_1_1482 DIMENSION_DATA Lnet/minecraft/class_1_206;
+	FIELD field_1_1483 GENERATED Lnet/minecraft/class_1_206;
+	FIELD field_1_1484 LOGGER Lorg/slf4j/Logger;
+	FIELD field_1_1485 OLD_END Lnet/minecraft/class_1_206;
+	FIELD field_1_1486 OLD_NETHER Lnet/minecraft/class_1_206;
+	FIELD field_1_1488 SELF Lnet/minecraft/class_1_206;
+	FIELD field_1_1489 PLAYER_DATA Lnet/minecraft/class_1_206;
+	FIELD field_1_1490 REGION Lnet/minecraft/class_1_206;
+	METHOD method_1_1762 getSubDirectories (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1763 findDimensionPaths (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1764 ofDimensionData (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_1_206;
+		ARG 0 dimension
+		ARG 1 dataPath
+	METHOD method_1_1765 withRelative (Ljava/lang/String;)Lnet/minecraft/class_1_206;
+		ARG 1 path
+	METHOD method_1_1766 getDimensionPaths (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 saveDirectory
+	METHOD method_1_1767 get (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 1 path
+	METHOD method_1_1768 ofCombined ([Lnet/minecraft/class_1_206;)Lnet/minecraft/class_1_206;
+		ARG 1 directoriesPaths
+	METHOD method_1_1769 (Ljava/nio/file/Path;)Z
+		ARG 0 pathx
+	METHOD method_1_1770 (Ljava/nio/file/Path;)Z
+		ARG 0 pathx
+	METHOD method_1_1771 (Ljava/nio/file/Path;)Ljava/util/stream/Stream;
+		ARG 0 pathx
+	METHOD method_1_1772 (Ljava/lang/String;Ljava/lang/String;Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 2 path
+	METHOD method_1_1773 (Ljava/lang/String;Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 1 pathx
+	METHOD method_1_1774 ([Lnet/minecraft/class_1_206;Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 1 path
+	METHOD method_1_1775 (Lnet/minecraft/class_1_206;Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 2 path
+	METHOD method_1_1776 (Lnet/minecraft/class_1_206;Ljava/nio/file/Path;)Ljava/util/stream/Stream;
+		ARG 1 pathx
+	METHOD method_1_1777 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1778 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1779 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1780 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1781 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1782 (Ljava/nio/file/Path;)Ljava/util/List;
+		ARG 0 path
+	METHOD method_1_1783 compose (Lnet/minecraft/class_1_206;)Lnet/minecraft/class_1_206;
+		ARG 1 relativePaths

--- a/mappings/net/minecraft/datafixer/file/FileFixUtil.mapping
+++ b/mappings/net/minecraft/datafixer/file/FileFixUtil.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_1_189 net/minecraft/datafixer/file/FileFixUtil
+	FIELD field_1_1411 LOGGER Lorg/slf4j/Logger;
+	METHOD method_1_1686 deleteFile (Ljava/nio/file/Path;Ljava/lang/String;)V
+		COMMENT Deletes a file or empty directory.
+		ARG 0 directory
+			COMMENT the working directory
+		ARG 1 path
+			COMMENT the path to the file to delete, resolved relative to {@code directory}
+	METHOD method_1_1687 moveFile (Ljava/nio/file/Path;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 0 path
+		ARG 1 from
+		ARG 2 to

--- a/mappings/net/minecraft/datafixer/file/FileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/FileFixer.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1_243 net/minecraft/datafixer/file/FileFixer
+	METHOD method_1_1921 update (Ljava/nio/file/Path;Lnet/minecraft/class_1_27;)V
+		ARG 1 path
+		ARG 2 progress

--- a/mappings/net/minecraft/datafixer/file/FileFixerUtil.mapping
+++ b/mappings/net/minecraft/datafixer/file/FileFixerUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1_189 net/minecraft/datafixer/file/FileFixUtil
+CLASS net/minecraft/class_1_189 net/minecraft/datafixer/file/FileFixerUtil
 	FIELD field_1_1411 LOGGER Lorg/slf4j/Logger;
 	METHOD method_1_1686 deleteFile (Ljava/nio/file/Path;Ljava/lang/String;)V
 		COMMENT Deletes a file or empty directory.

--- a/mappings/net/minecraft/datafixer/file/FileFixers.mapping
+++ b/mappings/net/minecraft/datafixer/file/FileFixers.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_1_248 net/minecraft/datafixer/file/FileFixers
+	METHOD method_1_1947 directories (Lnet/minecraft/class_1_206;Ljava/util/List;)Lnet/minecraft/class_1_234;
+		ARG 0 paths
+		ARG 1 fixers
+	METHOD method_1_1948 delete (Ljava/lang/String;)Lnet/minecraft/class_1_263;
+		ARG 0 path
+	METHOD method_1_1949 batchMove (Ljava/util/Map;Ljava/util/List;)Lnet/minecraft/class_1_214;
+		ARG 0 fromTo
+		ARG 1 fixers
+	METHOD method_1_1950 move (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_1_198;
+		ARG 0 from
+		ARG 1 to
+	METHOD method_1_1951 regexMove (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_1_215;
+		ARG 0 fromPattern
+		ARG 1 toPattern
+	METHOD method_1_1952 move (Ljava/lang/String;)Lnet/minecraft/class_1_198;
+		ARG 0 path

--- a/mappings/net/minecraft/datafixer/file/RegexMoveFileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/RegexMoveFileFixer.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1_215 net/minecraft/datafixer/file/RegexMoveFileFixer
+	METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 fromPattern
+		ARG 2 toPattern

--- a/mappings/net/minecraft/datafixer/file/SimpleMoveFileFixer.mapping
+++ b/mappings/net/minecraft/datafixer/file/SimpleMoveFileFixer.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1_198 net/minecraft/datafixer/file/SimpleMoveFileFixer
+	METHOD method_1_1721 withRelative (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_1_198;
+		ARG 1 fromDirectory
+		ARG 2 toDirectory

--- a/mappings/net/minecraft/datafixer/file/fix/DeleteDataFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/DeleteDataFileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_256 net/minecraft/datafixer/file/fix/DeleteDataFileFix

--- a/mappings/net/minecraft/datafixer/file/fix/DimensionDataFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/DimensionDataFileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_250 net/minecraft/datafixer/file/fix/DimensionDataFileFix

--- a/mappings/net/minecraft/datafixer/file/fix/DimensionStateFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/DimensionStateFileFix.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/class_1_255 net/minecraft/datafixer/file/fix/DimensionStateFileFix
+	FIELD field_1_1626 NIL_UUID Ljava/util/UUID;
+	FIELD field_1_1627 OVERWORLD Ljava/lang/String;
+	FIELD field_1_1628 THE_END Ljava/lang/String;
+	FIELD field_1_1629 THE_NETHER Ljava/lang/String;
+	FIELD field_1_1630 WORLD_BORDER_DATA_PATH Ljava/lang/String;
+	FIELD field_1_1631 WORLD_BORDER Ljava/lang/String;
+	METHOD method_1_1985 fixSingleplayerData (Lnet/minecraft/class_1_203;Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_1986 fixPersistentState (Lnet/minecraft/class_1_203;Lcom/mojang/serialization/Dynamic;Ljava/lang/String;)Lcom/mojang/serialization/Dynamic;
+		ARG 2 elementName
+	METHOD method_1_1987 fixWorldBorder (Lnet/minecraft/class_1_203;Lcom/mojang/serialization/Dynamic;D)V
+	METHOD method_1_1988 fixWorldBorders (Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+		ARG 0 overworld
+		ARG 1 theNether
+		ARG 2 theEnd
+	METHOD method_1_1989 fixWorldGenSettings (Lnet/minecraft/class_1_203;Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_1993 (Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_203;Lnet/minecraft/class_1_27;)V
+		ARG 14 progress

--- a/mappings/net/minecraft/datafixer/file/fix/FileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/FileFix.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_1_187 net/minecraft/datafixer/file/fix/FileFix
+	FIELD field_1_1395 fixers Ljava/util/List;
+	FIELD field_1_1396 outputSchema Lcom/mojang/datafixers/schemas/Schema;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 outputSchema
+	METHOD method_1_1646 addFixer (Lnet/minecraft/class_1_243;)V
+		ARG 1 fixer
+	METHOD method_1_1647 getFixerCount ()I
+	METHOD method_1_1648 getOutputSchema ()Lcom/mojang/datafixers/schemas/Schema;
+	METHOD method_1_1649 getVersion ()I
+	METHOD method_1_1650 init ()V
+	METHOD method_1_1651 fix (Ljava/nio/file/Path;Lnet/minecraft/class_1_27;)V
+		ARG 1 directory
+		ARG 2 progress

--- a/mappings/net/minecraft/datafixer/file/fix/GeneratedStructuresFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/GeneratedStructuresFileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_265 net/minecraft/datafixer/file/fix/GeneratedStructuresFileFix

--- a/mappings/net/minecraft/datafixer/file/fix/PlayerDataFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/PlayerDataFileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_238 net/minecraft/datafixer/file/fix/PlayerDataFileFix

--- a/mappings/net/minecraft/datafixer/file/fix/StructuresFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/StructuresFileFix.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_1_245 net/minecraft/datafixer/file/fix/StructuresFileFix
+	FIELD field_1_1606 THE_END Lnet/minecraft/class_5321;
+	FIELD field_1_1607 END_CITY Ljava/util/List;
+	FIELD field_1_1608 STRUCTURE_NAME_MAP Ljava/util/Map;
+	FIELD field_1_1609 THE_NETHER Lnet/minecraft/class_5321;
+	FIELD field_1_1610 FORTRESS Ljava/util/List;
+	FIELD field_1_1611 OVERWORLD Lnet/minecraft/class_5321;
+	METHOD method_1_1927 (Lcom/mojang/serialization/Dynamic;Ljava/util/List;Lnet/minecraft/class_1_27;)V
+		ARG 2 progress
+	METHOD method_1_1938 (Ljava/util/HashMap;)V
+		ARG 0 map
+	METHOD method_1_1943 (Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;Lnet/minecraft/class_1_196;Lnet/minecraft/class_2487;Lnet/minecraft/class_1_27;)V
+		ARG 3 progress

--- a/mappings/net/minecraft/datafixer/file/fix/WorldResourcePackFileFix.mapping
+++ b/mappings/net/minecraft/datafixer/file/fix/WorldResourcePackFileFix.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_257 net/minecraft/datafixer/file/fix/WorldResourcePackFileFix

--- a/mappings/net/minecraft/datafixer/fix/LevelDatDifficultyFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/LevelDatDifficultyFix.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_1_242 net/minecraft/datafixer/fix/LevelDatDifficultyFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 outputSchema

--- a/mappings/net/minecraft/datafixer/fix/LevelSplitSavedDataPreparationFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/LevelSplitSavedDataPreparationFix.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_1_267 net/minecraft/datafixer/fix/LevelSplitSavedDataPreparationFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 outputSchema
+	METHOD method_1_2028 fixDragonFight (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_2029 fixTimer (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_2030 fixWanderingTrader (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_2031 fixWeather (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_1_2032 fixWorldGenSettings (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;

--- a/mappings/net/minecraft/datafixer/schema/Schema4771.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema4771.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_1_192 net/minecraft/datafixer/schema/Schema4771

--- a/mappings/net/minecraft/entity/boss/BossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/BossBar.mapping
@@ -7,6 +7,11 @@ CLASS net/minecraft/class_1259 net/minecraft/entity/boss/BossBar
 	FIELD field_5777 name Lnet/minecraft/class_2561;
 	FIELD field_5778 color Lnet/minecraft/class_1259$class_1260;
 	FIELD field_5779 style Lnet/minecraft/class_1259$class_1261;
+	METHOD <init> (Ljava/util/UUID;Lnet/minecraft/class_2561;Lnet/minecraft/class_1259$class_1260;Lnet/minecraft/class_1259$class_1261;)V
+		ARG 1 uuid
+		ARG 2 name
+		ARG 3 color
+		ARG 4 style
 	METHOD method_5406 setDarkenSky (Z)Lnet/minecraft/class_1259;
 		ARG 1 darkenSky
 	METHOD method_5407 getUuid ()Ljava/util/UUID;

--- a/mappings/net/minecraft/entity/boss/BossBarManager.mapping
+++ b/mappings/net/minecraft/entity/boss/BossBarManager.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/class_3004 net/minecraft/entity/boss/BossBarManager
 	METHOD method_12968 getIds ()Ljava/util/Collection;
 	METHOD method_12969 getAll ()Ljava/util/Collection;
 	METHOD method_12970 add (Lnet/minecraft/class_5819;Lnet/minecraft/class_2960;Lnet/minecraft/class_2561;)Lnet/minecraft/class_3002;
+		ARG 1 random
+		ARG 2 id
 		ARG 3 displayName
 	METHOD method_12971 get (Lnet/minecraft/class_2960;)Lnet/minecraft/class_3002;
 		ARG 1 id

--- a/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
@@ -1,9 +1,15 @@
 CLASS net/minecraft/class_3002 net/minecraft/entity/boss/CommandBossBar
+	FIELD field_1_1515 modificationCallback Ljava/lang/Runnable;
 	FIELD field_13440 playerUuids Ljava/util/Set;
 	FIELD field_13441 id Lnet/minecraft/class_2960;
 	FIELD field_13442 maxValue I
 	FIELD field_13443 value I
 	FIELD field_56602 DEFAULT_MAX_VALUE I
+	METHOD <init> (Ljava/util/UUID;Lnet/minecraft/class_2960;Lnet/minecraft/class_2561;Ljava/lang/Runnable;)V
+		ARG 1 uuid
+		ARG 2 id
+		ARG 3 name
+		ARG 4 modificationCallback
 	METHOD method_12954 setValue (I)V
 		ARG 1 value
 	METHOD method_12955 getValue ()I

--- a/mappings/net/minecraft/entity/boss/ServerBossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/ServerBossBar.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_3213 net/minecraft/entity/boss/ServerBossBar
 		ARG 2 displayName
 		ARG 3 color
 		ARG 4 style
+	METHOD method_1_1714 markDirty ()V
 	METHOD method_14088 addPlayer (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_14089 removePlayer (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonFight.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonFight.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_2881 net/minecraft/entity/boss/dragon/EnderDragonFight
+	FIELD field_1_1619 BOSS_BAR_NAME Lnet/minecraft/class_2561;
+	FIELD field_1_1620 TYPE Lnet/minecraft/class_10741;
 	FIELD field_13105 crystalCountTimer I
 	FIELD field_13106 endCrystalsAlive I
 	FIELD field_13107 dragonSeenTimer I
@@ -24,6 +26,41 @@ CLASS net/minecraft/class_2881 net/minecraft/entity/boss/dragon/EnderDragonFight
 	FIELD field_44876 showBossBarPredicate Ljava/util/function/Predicate;
 	FIELD field_44877 origin Lnet/minecraft/class_2338;
 	FIELD field_44878 skipChunksLoadedCheck Z
+	METHOD <init> (ZZZLjava/util/Optional;ILjava/util/Optional;Ljava/util/Optional;Ljava/util/List;Ljava/util/List;)V
+		ARG 1 doLegacyCheck
+		ARG 2 dragonKilled
+		ARG 3 previouslyKilled
+		ARG 4 dragonSpawnState
+		ARG 5 spawnStateTimer
+		ARG 6 dragonUuid
+		ARG 7 exitPortalLocation
+		ARG 8 gateways
+		ARG 9 crystals
+	METHOD method_1_1962 ofDefault ()Lnet/minecraft/class_2881;
+	METHOD method_1_1963 initWorld (Lnet/minecraft/class_3218;JLnet/minecraft/class_2338;)V
+		ARG 1 world
+		ARG 2 gatewaySeed
+		ARG 4 origin
+	METHOD method_1_1965 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_1_1966 (Lnet/minecraft/class_2881;)Ljava/lang/Boolean;
+		ARG 0 state
+	METHOD method_1_1967 (Lnet/minecraft/class_2881;)Ljava/lang/Boolean;
+		ARG 0 state
+	METHOD method_1_1968 (Lnet/minecraft/class_2881;)Ljava/lang/Boolean;
+		ARG 0 state
+	METHOD method_1_1969 (Lnet/minecraft/class_2881;)Ljava/util/Optional;
+		ARG 0 state
+	METHOD method_1_1970 (Lnet/minecraft/class_2881;)Ljava/lang/Integer;
+		ARG 0 state
+	METHOD method_1_1971 (Lnet/minecraft/class_2881;)Ljava/util/Optional;
+		ARG 0 state
+	METHOD method_1_1972 (Lnet/minecraft/class_2881;)Ljava/util/Optional;
+		ARG 0 state
+	METHOD method_1_1973 (Lnet/minecraft/class_2881;)Ljava/util/List;
+		ARG 0 state
+	METHOD method_1_1974 (Lnet/minecraft/class_2881;)Ljava/util/List;
+		ARG 0 state
 	METHOD method_12514 worldContainsEndPortal ()Z
 	METHOD method_12515 convertFromLegacy ()V
 	METHOD method_12516 generateEndGateway (Lnet/minecraft/class_2338;)V

--- a/mappings/net/minecraft/nbt/NbtHelper.mapping
+++ b/mappings/net/minecraft/nbt/NbtHelper.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
 	FIELD field_33227 COMMA Ljava/lang/String;
 	FIELD field_33228 COLON C
 	FIELD field_57978 BLOCK_KEY_CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_1_1641 getDataVersion (Lcom/mojang/serialization/Dynamic;)I
+		ARG 0 dynamic
 	METHOD method_10681 toBlockState (Lnet/minecraft/class_7871;Lnet/minecraft/class_2487;)Lnet/minecraft/class_2680;
 		COMMENT {@return the block state from the {@code nbt}}
 		COMMENT

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -16,6 +16,13 @@ CLASS net/minecraft/server/MinecraftServer
 	COMMENT @see net.minecraft.server.dedicated.MinecraftDedicatedServer
 	COMMENT @see net.minecraft.server.integrated.IntegratedServer
 	FIELD field_1_962 clocks Lnet/minecraft/class_1_109;
+	FIELD field_1_1399 SAFE_MODE_GAME_RULES Ljava/util/function/Supplier;
+	FIELD field_1_1401 gameRules Lnet/minecraft/class_1928;
+	FIELD field_1_1402 randomSequencesState Lnet/minecraft/class_8565;
+	FIELD field_1_1403 persistentStateManager Lnet/minecraft/class_26;
+	FIELD field_1_1404 timer Lnet/minecraft/class_236;
+	FIELD field_1_1405 weatherState Lnet/minecraft/class_1_216;
+	FIELD field_1_1406 worldGenSettings Lnet/minecraft/class_7726;
 	FIELD field_4543 onlineMode Z
 	FIELD field_4544 running Z
 	FIELD field_4546 LOGGER Lorg/slf4j/Logger;
@@ -108,6 +115,17 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_1_402 checkLowDiskSpaceWarning ()V
 	METHOD method_1_847 getClocks ()Lnet/minecraft/class_1_109;
 	METHOD method_1_848 getOverworldGameRules ()Lnet/minecraft/class_1928;
+	METHOD method_1_1665 getPersistentStateManager ()Lnet/minecraft/class_26;
+	METHOD method_1_1666 getGameRules ()Lnet/minecraft/class_1928;
+	METHOD method_1_1668 getRandomSequencesState ()Lnet/minecraft/class_8565;
+	METHOD method_1_1669 getScheduledEvents ()Lnet/minecraft/class_236;
+	METHOD method_1_1670 getWeatherState ()Lnet/minecraft/class_1_216;
+	METHOD method_1_1671 getWorldGenSettings ()Lnet/minecraft/class_7726;
+	METHOD method_1_1674 setWeatherState (IIZZ)V
+		ARG 1 clearWeatherTime
+		ARG 2 rainTime
+		ARG 3 raining
+		ARG 4 thundering
 	METHOD method_3716 getKeyPair ()Ljava/security/KeyPair;
 	METHOD method_3718 isFlightEnabled ()Z
 	METHOD method_3723 save (ZZZ)Z

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -49,6 +49,9 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 8 seed
 		ARG 10 spawners
 		ARG 11 shouldTickTime
+	METHOD method_1_1681 getWeatherState ()Lnet/minecraft/class_1_216;
+	METHOD method_1_1683 setWeatherGradients (Lnet/minecraft/class_1_216;)V
+		ARG 1 weatherState
 	METHOD method_8448 updateSleepingPlayers ()V
 	METHOD method_8487 locateStructure (Lnet/minecraft/class_6862;Lnet/minecraft/class_2338;IZ)Lnet/minecraft/class_2338;
 		COMMENT Tries to find the closest structure of a given type near a given block.

--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -99,6 +99,10 @@ CLASS net/minecraft/class_2960 net/minecraft/util/Identifier
 		ARG 1 other
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
+	METHOD method_1_1644 resolveInPath (Ljava/nio/file/Path;)Ljava/nio/file/Path;
+		COMMENT {@return a path representing the identifier, relative to the given path}
+		ARG 1 path
+			COMMENT the relative path the identifier should be resolved against
 	METHOD method_12829 tryParse (Ljava/lang/String;)Lnet/minecraft/class_2960;
 		COMMENT {@return {@code id} parsed as an identifier, or {@code null} if it cannot be parsed}
 		COMMENT

--- a/mappings/net/minecraft/world/WeatherState.mapping
+++ b/mappings/net/minecraft/world/WeatherState.mapping
@@ -1,0 +1,30 @@
+CLASS net/minecraft/class_1_216 net/minecraft/world/WeatherState
+	FIELD field_1_1527 TYPE Lnet/minecraft/class_10741;
+	FIELD field_1_1528 clearWeatherTime I
+	FIELD field_1_1529 rainTime I
+	FIELD field_1_1530 raining Z
+	FIELD field_1_1531 thunderTime I
+	FIELD field_1_1532 thundering Z
+	METHOD <init> (IIIZZ)V
+		ARG 1 clearWeatherTime
+		ARG 2 rainTime
+		ARG 3 thunderTime
+		ARG 4 raining
+		ARG 5 thundering
+	METHOD method_1_1823 getClearWeatherTime ()I
+	METHOD method_1_1824 getRainTime ()I
+	METHOD method_1_1825 getThunderTime ()I
+	METHOD method_1_1826 getRaining ()Z
+	METHOD method_1_1827 getThundering ()Z
+	METHOD method_1_1828 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_1_1829 setClearWeatherTime (I)V
+		ARG 1 clearWeatherTime
+	METHOD method_1_1830 setRainTime (I)V
+		ARG 1 rainTime
+	METHOD method_1_1831 setRaining (Z)V
+		ARG 1 raining
+	METHOD method_1_1832 setThunderTime (I)V
+		ARG 1 thunderTime
+	METHOD method_1_1833 setThundering (Z)V
+		ARG 1 thundering

--- a/mappings/net/minecraft/world/dimension/DimensionType.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionType.mapping
@@ -14,6 +14,7 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 		ARG 1 hasFixedTime
 		ARG 2 hasSkylight
 		ARG 3 hasCeiling
+		ARG 4 hasEnderDragonFight
 		ARG 5 coordinateScale
 		ARG 7 minY
 		ARG 8 height
@@ -25,6 +26,7 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 		ARG 14 cardinalLightType
 		ARG 15 attributes
 		ARG 16 timelines
+		ARG 17 defaultClock
 	METHOD comp_847 monsterSettings ()Lnet/minecraft/class_2874$class_7512;
 	METHOD comp_5219 hasFixedTime ()Z
 	METHOD method_12488 getSaveDirectory (Lnet/minecraft/class_5321;Ljava/nio/file/Path;)Ljava/nio/file/Path;

--- a/mappings/net/minecraft/world/gen/feature/BlockBlobFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BlockBlobFeature.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2950 net/minecraft/world/gen/feature/BlockBlobFeature

--- a/mappings/net/minecraft/world/gen/feature/BlockBlobFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BlockBlobFeatureConfig.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_1_280 net/minecraft/world/gen/feature/BlockBlobFeatureConfig
+	METHOD method_1_2072 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance

--- a/mappings/net/minecraft/world/gen/feature/ForestRockFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/ForestRockFeature.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2950 net/minecraft/world/gen/feature/ForestRockFeature

--- a/mappings/net/minecraft/world/gen/feature/HugeMushroomFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/HugeMushroomFeatureConfig.mapping
@@ -1,11 +1,16 @@
 CLASS net/minecraft/class_4635 net/minecraft/world/gen/feature/HugeMushroomFeatureConfig
-	FIELD comp_1_189 capProvider Lnet/minecraft/class_4651;
-	FIELD comp_1_190 foliageRadius I
-	FIELD comp_1_191 stemProvider Lnet/minecraft/class_4651;
 	FIELD field_24885 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_4651;Lnet/minecraft/class_4651;ILnet/minecraft/class_6646;)V
 		ARG 1 capProvider
 		ARG 2 stemProvider
 		ARG 3 foliageRadius
+	METHOD method_1_2088 (Lnet/minecraft/class_4635;)Lnet/minecraft/class_6646;
+		ARG 0 config
+	METHOD method_28720 (Lnet/minecraft/class_4635;)Ljava/lang/Integer;
+		ARG 0 config
 	METHOD method_28721 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
+	METHOD method_28722 (Lnet/minecraft/class_4635;)Lnet/minecraft/class_4651;
+		ARG 0 config
+	METHOD method_28723 (Lnet/minecraft/class_4635;)Lnet/minecraft/class_4651;
+		ARG 0 config

--- a/mappings/net/minecraft/world/gen/feature/IceSpikeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/IceSpikeFeature.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_3070 net/minecraft/world/gen/feature/IceSpikeFeature

--- a/mappings/net/minecraft/world/gen/feature/SpikeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/SpikeFeature.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_3070 net/minecraft/world/gen/feature/SpikeFeature

--- a/mappings/net/minecraft/world/gen/feature/SpikeFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/SpikeFeatureConfig.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_1_275 net/minecraft/world/gen/feature/SpikeFeatureConfig
+	METHOD method_1_2071 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance

--- a/mappings/net/minecraft/world/gen/feature/TreeFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/TreeFeatureConfig.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_4643 net/minecraft/world/gen/feature/TreeFeatureConfig
+	FIELD field_1_1675 CAN_REPLACE_BELOW_TRUNK Lnet/minecraft/class_6646;
+	FIELD field_1_1676 DEFAULT_BELOW_TRUNK_PROVIDER Lnet/minecraft/class_7400;
 	FIELD field_21288 trunkProvider Lnet/minecraft/class_4651;
 	FIELD field_21290 decorators Ljava/util/List;
 	FIELD field_24135 foliagePlacer Lnet/minecraft/class_4647;
@@ -18,6 +20,7 @@ CLASS net/minecraft/class_4643 net/minecraft/world/gen/feature/TreeFeatureConfig
 		ARG 6 minimumSize
 		ARG 7 decorators
 		ARG 8 ignoreVines
+		ARG 9 belowTrunkProvider
 	METHOD method_28811 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	METHOD method_28814 (Lnet/minecraft/class_4643;)Lnet/minecraft/class_5201;
@@ -46,12 +49,16 @@ CLASS net/minecraft/class_4643 net/minecraft/world/gen/feature/TreeFeatureConfig
 		FIELD field_24142 minimumSize Lnet/minecraft/class_5201;
 		FIELD field_24143 ignoreVines Z
 		FIELD field_29282 foliageProvider Lnet/minecraft/class_4651;
-		FIELD field_29283 dirtProvider Lnet/minecraft/class_7400;
+		FIELD field_29283 belowTrunkProvider Lnet/minecraft/class_7400;
 		FIELD field_38768 rootPlacer Ljava/util/Optional;
 		METHOD <init> (Lnet/minecraft/class_4651;Lnet/minecraft/class_5141;Lnet/minecraft/class_4651;Lnet/minecraft/class_4647;Ljava/util/Optional;Lnet/minecraft/class_5201;Lnet/minecraft/class_7400;)V
 			ARG 1 trunkProvider
 			ARG 2 trunkPlacer
 			ARG 3 foliageProvider
+			ARG 4 foliagePlacer
+			ARG 5 rootPlacer
+			ARG 6 minimumSize
+			ARG 7 belowTrunkProvider
 		METHOD <init> (Lnet/minecraft/class_4651;Lnet/minecraft/class_5141;Lnet/minecraft/class_4651;Lnet/minecraft/class_4647;Lnet/minecraft/class_5201;)V
 			ARG 1 trunkProvider
 			ARG 2 trunkPlacer
@@ -62,4 +69,5 @@ CLASS net/minecraft/class_4643 net/minecraft/world/gen/feature/TreeFeatureConfig
 		METHOD method_27374 ignoreVines ()Lnet/minecraft/class_4643$class_4644;
 		METHOD method_27376 decorators (Ljava/util/List;)Lnet/minecraft/class_4643$class_4644;
 			ARG 1 decorators
-		METHOD method_34346 dirtProvider (Lnet/minecraft/class_7400;)Lnet/minecraft/class_4643$class_4644;
+		METHOD method_34346 belowTrunkProvider (Lnet/minecraft/class_7400;)Lnet/minecraft/class_4643$class_4644;
+			ARG 1 belowTrunkProvider

--- a/mappings/net/minecraft/world/gen/stateprovider/PredicatedStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/PredicatedStateProvider.mapping
@@ -1,12 +1,25 @@
 CLASS net/minecraft/class_7400 net/minecraft/world/gen/stateprovider/PredicatedStateProvider
 	FIELD field_38870 CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (Ljava/util/Optional;Ljava/util/List;)V
+		ARG 1 fallback
+		ARG 2 rules
+	METHOD method_1_2082 of (Lnet/minecraft/class_6646;Lnet/minecraft/class_2248;)Lnet/minecraft/class_7400;
+		ARG 0 ifTrue
+		ARG 1 then
+	METHOD method_1_2083 of (Lnet/minecraft/class_6646;Lnet/minecraft/class_4651;)Lnet/minecraft/class_7400;
+		ARG 0 ifTrue
+		ARG 1 then
 	METHOD method_43311 getBlockState (Lnet/minecraft/class_5281;Lnet/minecraft/class_5819;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
 		ARG 1 world
 		ARG 2 random
 		ARG 3 pos
 	METHOD method_43312 of (Lnet/minecraft/class_2248;)Lnet/minecraft/class_7400;
 		ARG 0 block
+	METHOD method_43313 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
 	METHOD method_43314 of (Lnet/minecraft/class_4651;)Lnet/minecraft/class_7400;
 		ARG 0 stateProvider
 	CLASS class_7401 Rule
 		FIELD field_38871 CODEC Lcom/mojang/serialization/Codec;
+		METHOD method_43315 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance

--- a/mappings/net/minecraft/world/gen/treedecorator/AlterGroundTreeDecorator.mapping
+++ b/mappings/net/minecraft/world/gen/treedecorator/AlterGroundTreeDecorator.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/class_4658 net/minecraft/world/gen/treedecorator/AlterGroundTreeDecorator
 	FIELD field_21316 provider Lnet/minecraft/class_7400;
 	FIELD field_24957 CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD <init> (Lnet/minecraft/class_7400;)V
+		ARG 1 provider
 	METHOD method_23460 (ILnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_23461 (Lnet/minecraft/class_4662$class_7402;Lnet/minecraft/class_2338;)V

--- a/mappings/net/minecraft/world/timer/Timer.mapping
+++ b/mappings/net/minecraft/world/timer/Timer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_236 net/minecraft/world/timer/Timer
+	FIELD field_1_1451 TYPE Lnet/minecraft/class_10741;
 	FIELD field_1311 eventCounter Lcom/google/common/primitives/UnsignedLong;
 	FIELD field_1312 eventsByName Lcom/google/common/collect/Table;
 	FIELD field_1313 events Ljava/util/Queue;

--- a/mappings/net/minecraft/world/updater/WorldUpdateProgress.mapping
+++ b/mappings/net/minecraft/world/updater/WorldUpdateProgress.mapping
@@ -8,6 +8,12 @@ CLASS net/minecraft/class_1_27 net/minecraft/world/updater/WorldUpdateProgress
 	FIELD field_1_217 status Lnet/minecraft/class_1_27$class_1_29;
 	FIELD field_1_218 totalChunkCount Ljava/util/concurrent/atomic/AtomicInteger;
 	FIELD field_1_220 progress F
+	FIELD field_1_1493 LOGGER Lorg/slf4j/Logger;
+	FIELD field_1_1494 lastLogTimeMs Ljava/util/concurrent/atomic/AtomicLong;
+	FIELD field_1_1495 fileFixProgress Lnet/minecraft/class_1_27$class_1_209;
+	FIELD field_1_1496 conversionProgress Lnet/minecraft/class_1_27$class_1_209;
+	FIELD field_1_1497 perStageProgress Lnet/minecraft/class_1_27$class_1_209;
+	FIELD field_1_1498 stage Lnet/minecraft/class_1_27$class_1_210;
 	METHOD method_1_492 addTotalChunkCount (I)V
 		ARG 1 count
 	METHOD method_1_494 getUpgradedChunkCount ()I
@@ -34,9 +40,31 @@ CLASS net/minecraft/class_1_27 net/minecraft/world/updater/WorldUpdateProgress
 		ARG 1 status
 	METHOD method_1_511 setProgress (F)V
 		ARG 1 progress
+	METHOD method_1_1785 incrementTotal (I)V
+		ARG 1 increment
+	METHOD method_1_1786 getFileFixProgress ()Lnet/minecraft/class_1_27$class_1_209;
+	METHOD method_1_1787 getConversionProgress ()Lnet/minecraft/class_1_27$class_1_209;
+	METHOD method_1_1788 getStage ()Lnet/minecraft/class_1_27$class_1_210;
+	METHOD method_1_1789 getPerStageProgress ()Lnet/minecraft/class_1_27$class_1_209;
+	METHOD method_1_1790 incrementConversionsDone ()V
+	METHOD method_1_1791 incrementConversionsDone (I)V
+		ARG 1 increment
+	METHOD method_1_1792 incrementFileFixDone ()V
+	METHOD method_1_1793 logProgress ()V
+	METHOD method_1_1794 setFileFixTotal (I)V
+		ARG 1 total
+	METHOD method_1_1795 setStage (Lnet/minecraft/class_1_27$class_1_210;)V
+		ARG 1 stage
 	CLASS class_1_28 Dummy
 	CLASS class_1_29 Status
-	CLASS class_1_210 Type
+	CLASS class_1_209 Ratio
+		FIELD field_1_1499 done Ljava/util/concurrent/atomic/AtomicInteger;
+		FIELD field_1_1500 total Ljava/util/concurrent/atomic/AtomicInteger;
+		METHOD method_1_1796 getDone ()I
+		METHOD method_1_1797 getProgress ()F
+		METHOD method_1_1798 reset ()V
+		METHOD method_1_1799 getTotal ()I
+	CLASS class_1_210 Stage
 		FIELD field_1_1505 name Ljava/lang/String;
 		FIELD field_1_1506 text Lnet/minecraft/class_2561;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V

--- a/mappings/net/minecraft/world/updater/WorldUpdateProgress.mapping
+++ b/mappings/net/minecraft/world/updater/WorldUpdateProgress.mapping
@@ -36,3 +36,9 @@ CLASS net/minecraft/class_1_27 net/minecraft/world/updater/WorldUpdateProgress
 		ARG 1 progress
 	CLASS class_1_28 Dummy
 	CLASS class_1_29 Status
+	CLASS class_1_210 Type
+		FIELD field_1_1505 name Ljava/lang/String;
+		FIELD field_1_1506 text Lnet/minecraft/class_2561;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
+		METHOD method_1_1801 asText ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
Some mappings to start. Has the feature changes in worldgen (but no structures), a few server (mostly persistent state stuff) changes, as well as the file fixers for the world storage upgrade (but no other fixer things).

I'm unsure about `DirectoryPaths` for `class_1_206`, can't think of something better though. Maybe a ‘provider’ or ‘supplier’ suffix could help? I'll just submit it as is though, for now.