### PR TITLE
[26.1.2 fix] Correct parameter name for BlockLootTableGenerator#candleCakeDrops

### DIFF
--- a/mappings/net/minecraft/data/loottable/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/loottable/BlockLootTableGenerator.mapping
@@ -133,7 +133,7 @@ CLASS net/minecraft/class_7788 net/minecraft/data/loottable/BlockLootTableGenera
 	METHOD method_46020 candleDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
 		ARG 1 candle
 	METHOD method_46021 candleCakeDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-		ARG 0 candleCake
+		ARG 0 candle
 	METHOD method_46022 doorDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
 		ARG 1 block
 	METHOD method_46023 addPottedPlantDrops (Lnet/minecraft/class_2248;)V


### PR DESCRIPTION
This method gets the candle block passed in, not the candle cake block.

Can probably be applied on the snapshot mappings as is.