### PR TITLE
[26.1.2] Resolve `Pool` name collision

### DIFF
--- a/mappings/com/mojang/blaze3d/buffers/BufferAllocator.mapping
+++ b/mappings/com/mojang/blaze3d/buffers/BufferAllocator.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_9799 net/minecraft/client/util/BufferAllocator
+CLASS net/minecraft/class_9799 com/mojang/blaze3d/buffers/BufferAllocator
 	FIELD field_52078 LOGGER Lorg/slf4j/Logger;
 	FIELD field_52079 ALLOCATOR Lorg/lwjgl/system/MemoryUtil$MemoryAllocator;
 	FIELD field_52080 MIN_GROWTH I

--- a/mappings/net/minecraft/client/util/memory/ObjectAllocator.mapping
+++ b/mappings/net/minecraft/client/util/memory/ObjectAllocator.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_9922 net/minecraft/client/util/ObjectAllocator
+CLASS net/minecraft/class_9922 net/minecraft/client/util/memory/ObjectAllocator
 	FIELD field_52741 TRIVIAL Lnet/minecraft/class_9922;
 	METHOD method_61948 acquire (Lnet/minecraft/class_9924;)Ljava/lang/Object;
 		ARG 1 factory

--- a/mappings/net/minecraft/client/util/memory/ObjectPool.mapping
+++ b/mappings/net/minecraft/client/util/memory/ObjectPool.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_9920 net/minecraft/client/util/Pool
+CLASS net/minecraft/class_9920 net/minecraft/client/util/memory/ObjectPool
 	FIELD field_52736 lifespan I
 	FIELD field_52737 entries Ljava/util/Deque;
 	METHOD <init> (I)V

--- a/mappings/net/minecraft/util/collection/ShufflingList.mapping
+++ b/mappings/net/minecraft/util/collection/ShufflingList.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_6032 net/minecraft/util/collection/WeightedList
+CLASS net/minecraft/class_6032 net/minecraft/util/collection/ShufflingList
 	FIELD field_30169 entries Ljava/util/List;
 	FIELD field_30170 random Lnet/minecraft/class_5819;
 	METHOD <init> (Ljava/util/List;)V

--- a/mappings/net/minecraft/util/collection/WeightedPool.mapping
+++ b/mappings/net/minecraft/util/collection/WeightedPool.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_6012 net/minecraft/util/collection/Pool
+CLASS net/minecraft/class_6012 net/minecraft/util/collection/WeightedPool
 	FIELD field_29934 totalWeight I
 	FIELD field_29935 entries Ljava/util/List;
 	FIELD field_55646 FLATTENED_CONTENT_THRESHOLD I


### PR DESCRIPTION
## Executive summary

* `net.minecraft.client.util.Pool` has been renamed to `ObjectPool` to remove the name collision with `net.minecraft.util.collection.Pool`.
* `net.minecraft.util.collection.Pool` has been renamed to `WeightedPool` (the official name is likely `WeightedList` as mentioned in error messages, but there is an existing class with this as its Yarn name).
* `WeightedList` has been renamed to `ShufflingList` (mentioned in its `toString` implementation).
* Several memory-related client util classes have been moved to their own package.

See #51 for 26.2-snapshot-8.